### PR TITLE
feat(chat): add per-folder chats sidebar

### DIFF
--- a/src/lib/chatTabId.ts
+++ b/src/lib/chatTabId.ts
@@ -1,0 +1,16 @@
+import type { AiBackend } from "@shellular/protocol";
+
+/**
+ * Stable id for a chat used both as its page-stack id and its key in the
+ * per-folder chat cache (`chatTabs`).
+ *
+ * An existing session is keyed by `agent:session` so re-opening it reuses the
+ * same page/cache entry. A brand-new chat (no session yet) gets a unique id so
+ * multiple new chats — possibly for different agents in the same folder — never
+ * collide.
+ */
+export function chatTabId(agentId: AiBackend, sessionId: string): string {
+	return sessionId
+		? `chat:${agentId}:${sessionId}`
+		: `chat:new:${agentId}:${Date.now()}:${Math.random().toString(36).slice(2, 7)}`;
+}

--- a/src/pages/bookmark-sessions/index.tsx
+++ b/src/pages/bookmark-sessions/index.tsx
@@ -4,6 +4,7 @@ import AppMenu from "components/AppMenu";
 import EmptyState from "components/EmptyState";
 import Page from "components/Page";
 import { getAgentIcon } from "lib/agents";
+import { chatTabId } from "lib/chatTabId";
 import { formatRelativeTime } from "lib/utils";
 import { useCallback } from "react";
 import { useShellular } from "state";
@@ -28,10 +29,12 @@ export default function BookmarkSessionsPage() {
 		async (bookmark: BookmarkedSession) => {
 			const agent = agents[bookmark.agentId];
 			if (!agent?.available) return;
+			const tabId = chatTabId(bookmark.agentId, bookmark.sessionId);
 			const ChatConversationPage = await import("pages/chat");
 			pushPage(
-				bookmark.sessionId,
+				tabId,
 				<ChatConversationPage.default
+					chatTabId={tabId}
 					sessionId={bookmark.sessionId}
 					title={bookmark.title}
 					agentId={bookmark.agentId}

--- a/src/pages/chat/ChatSidebar.tsx
+++ b/src/pages/chat/ChatSidebar.tsx
@@ -1,0 +1,262 @@
+import { pushPage } from "App";
+import type { AiBackend } from "@shellular/protocol";
+import AgentIcon from "components/AgentIcon";
+import { getAgentIcon } from "lib/agents";
+import { useEffect, useState } from "react";
+import { useShellular } from "state";
+import type { AcpAgentInfo } from "state/acp";
+import { type ChatTab, removeChatTab, useChatTabs } from "state/chatTabs";
+import {
+	getSessionStreaming,
+	listenToSessionStreamingEvent,
+} from "state/sessions";
+
+/**
+ * Slide-in sidebar (from the right) listing the chats opened in this chat's
+ * folder, cached locally in the `chatTabs` store. Selecting a chat or starting a
+ * new one pushes a fresh `ChatConversationPage`. Rendered inside the chat page —
+ * there is no separate workspace component.
+ */
+export default function ChatSidebar({
+	open,
+	onClose,
+	workspacePath,
+	activeTabId,
+}: {
+	open: boolean;
+	onClose: () => void;
+	workspacePath: string;
+	/** Local id of the chat currently being viewed, to highlight it. */
+	activeTabId: string;
+}) {
+	const { agents } = useShellular();
+	const tabs = useChatTabs(workspacePath);
+	const folderName =
+		workspacePath.split("/").filter(Boolean).pop() || workspacePath;
+
+	const availableAgents = Object.values(agents).filter(
+		(agent) => agent.available,
+	);
+	const singleAgent = availableAgents.length === 1 ? availableAgents[0] : null;
+
+	// Keep the panel mounted briefly while it animates out.
+	const [mounted, setMounted] = useState(open);
+	useEffect(() => {
+		if (open) {
+			setMounted(true);
+			return;
+		}
+		const timer = window.setTimeout(() => setMounted(false), 220);
+		return () => window.clearTimeout(timer);
+	}, [open]);
+
+	if (!mounted) return null;
+
+	const openExisting = (tab: ChatTab) => {
+		onClose();
+		if (tab.id === activeTabId) return;
+		pushChat({
+			tabId: tab.id,
+			agentId: tab.agentId,
+			sessionId: tab.sessionId,
+			title: tab.title,
+			workspacePath,
+			agent: agents[tab.agentId],
+		});
+	};
+
+	const newChat = (agentId: AiBackend) => {
+		onClose();
+		const tabId = `chat:new:${agentId}:${Date.now()}`;
+		pushChat({
+			tabId,
+			agentId,
+			sessionId: "",
+			title: "New Chat",
+			workspacePath,
+			agent: agents[agentId],
+		});
+	};
+
+	return (
+		<div className={`project-chat-drawer ${open ? "is-open" : "is-closing"}`}>
+			<button
+				type="button"
+				className="project-chat-drawer-backdrop"
+				aria-label="Close chats"
+				onClick={onClose}
+			/>
+			<aside className="project-chat-drawer-panel">
+				<header className="project-chat-drawer-header">
+					<div className="project-chat-drawer-title">
+						<span className="icon-folder" aria-hidden="true" />
+						<span>{folderName}</span>
+					</div>
+					<button
+						type="button"
+						className="project-chat-drawer-close haptic-trigger"
+						onClick={onClose}
+						aria-label="Close"
+					>
+						<span className="icon-x" aria-hidden="true" />
+					</button>
+				</header>
+
+				<div className="project-chat-drawer-body">
+					{tabs.length === 0 && (
+						<p className="project-chat-drawer-empty">No chats yet</p>
+					)}
+					{tabs.map((tab) => (
+						<ChatTabRow
+							key={tab.id}
+							tab={tab}
+							agent={agents[tab.agentId]}
+							active={tab.id === activeTabId}
+							onSelect={() => openExisting(tab)}
+							onClose={() => removeChatTab(workspacePath, tab.id)}
+						/>
+					))}
+				</div>
+
+				<div className="project-chat-drawer-footer">
+					{availableAgents.length === 0 ? (
+						<p className="project-chat-drawer-empty">
+							No agents available on this device
+						</p>
+					) : singleAgent ? (
+						<button
+							type="button"
+							className="project-chat-new-btn haptic-trigger"
+							onClick={() => newChat(singleAgent.id)}
+						>
+							<span className="icon-plus" aria-hidden="true" />
+							New Chat
+						</button>
+					) : (
+						<>
+							<span className="project-chat-new-label">New chat</span>
+							<div className="project-chat-new-agents">
+								{availableAgents.map((agent) => (
+									<button
+										key={agent.id}
+										type="button"
+										className="project-chat-new-btn project-chat-new-btn--agent haptic-trigger"
+										onClick={() => newChat(agent.id)}
+									>
+										<AgentIcon
+											agent={agent}
+											className="project-chat-new-agent-icon"
+										/>
+										{agent.title || agent.name}
+									</button>
+								))}
+							</div>
+						</>
+					)}
+				</div>
+			</aside>
+		</div>
+	);
+}
+
+function ChatTabRow({
+	tab,
+	agent,
+	active,
+	onSelect,
+	onClose,
+}: {
+	tab: ChatTab;
+	agent: AcpAgentInfo | undefined;
+	active: boolean;
+	onSelect: () => void;
+	onClose: () => void;
+}) {
+	const [streaming, setStreaming] = useState(() =>
+		tab.sessionId ? getSessionStreaming(tab.agentId, tab.sessionId) : false,
+	);
+	useEffect(() => {
+		if (!tab.sessionId) {
+			setStreaming(false);
+			return;
+		}
+		const refresh = () =>
+			setStreaming(getSessionStreaming(tab.agentId, tab.sessionId));
+		refresh();
+		return listenToSessionStreamingEvent((agentId) => {
+			if (agentId === tab.agentId) refresh();
+		});
+	}, [tab.agentId, tab.sessionId]);
+
+	return (
+		<div className="project-chat-session-row" data-active={active}>
+			<button
+				type="button"
+				className="project-chat-session-main haptic-trigger"
+				onClick={onSelect}
+			>
+				<span className="project-chat-session-icon">
+					{agent ? (
+						<AgentIcon agent={agent} className="" />
+					) : (
+						<span className={getAgentIcon(tab.agentId)} aria-hidden="true" />
+					)}
+				</span>
+				<span className="project-chat-session-text">
+					<span className="project-chat-session-title">{tab.title}</span>
+					<span className="project-chat-session-meta">
+						{agent?.title ?? tab.agentId}
+						{!tab.sessionId ? " · draft" : ""}
+					</span>
+				</span>
+				{streaming && <span className="badge" />}
+			</button>
+			<button
+				type="button"
+				className="project-chat-session-close haptic-trigger"
+				onClick={onClose}
+				aria-label="Close chat"
+			>
+				<span className="icon-x" aria-hidden="true" />
+			</button>
+		</div>
+	);
+}
+
+/** Push a `ChatConversationPage` for the given chat identity. */
+function pushChat({
+	tabId,
+	agentId,
+	sessionId,
+	title,
+	workspacePath,
+	agent,
+}: {
+	tabId: string;
+	agentId: AiBackend;
+	sessionId: string;
+	title: string;
+	workspacePath: string;
+	agent: AcpAgentInfo | undefined;
+}) {
+	const agentName = agent?.name ?? agentId;
+	import("pages/chat").then((mod) => {
+		const ChatConversationPage = mod.default;
+		pushPage(
+			tabId,
+			<ChatConversationPage
+				chatTabId={tabId}
+				sessionId={sessionId}
+				agentId={agentId}
+				workspacePath={workspacePath}
+				title={title}
+				assistantName={agentName}
+				agentAvailable={agent?.available ?? true}
+				unavailableMessage={`${agentName} is not available on this device.`}
+				providerName={agent?.title ?? agentName}
+				agentCapabilities={agent?.capabilities}
+				createOnFirstMessage={!sessionId}
+			/>,
+		);
+	});
+}

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -13,6 +13,7 @@ import BottomSheet from "components/BottomSheet";
 import EmptyState from "components/EmptyState";
 import Loader from "components/Loader";
 import Page from "components/Page";
+import actionStack from "lib/actionStack";
 import { getAgentIcon } from "lib/agents";
 import { registerShellularDiffThemes } from "lib/diffsTheme";
 import keyboard from "lib/keyboard";
@@ -48,6 +49,7 @@ import {
 	acpSubscribeSessionEvents,
 	acpWriteAttachmentBase64,
 } from "state/acp";
+import { recordChatTab } from "state/chatTabs";
 import { listDir, searchProjectFiles } from "state/filesystem";
 import {
 	getSessionActivity,
@@ -75,6 +77,7 @@ import {
 	replaceComposerTrigger,
 	updateComposerAttachment,
 } from "./ChatComposer";
+import ChatSidebar from "./ChatSidebar";
 import ChatBubble from "./chat-bubble";
 import PermissionRequestCard from "./chat-bubble/components/PermissionRequestCard";
 import {
@@ -93,6 +96,15 @@ import {
 
 const PAGE_SIZE = 30;
 const STOP_REASON_METADATA = "stop-reason";
+// Placeholder title used for not-yet-named chats. Treated as "no real title" so
+// it never overwrites an actual session/activity title.
+const PLACEHOLDER_TITLE = "New Chat";
+
+function isRealTitle(value: unknown): value is string {
+	return (
+		typeof value === "string" && value.length > 0 && value !== PLACEHOLDER_TITLE
+	);
+}
 
 registerShellularDiffThemes();
 
@@ -108,6 +120,13 @@ export interface ChatConversationPageProps {
 	agentCapabilities?: Record<string, unknown>;
 	cacheMessages?: boolean;
 	createOnFirstMessage?: boolean;
+	/**
+	 * Stable local id for this chat in the per-folder chat cache (`chatTabs`).
+	 * The chat self-registers under this id and updates its sessionId/title as
+	 * they resolve, so the in-chat sidebar can list every chat in the folder.
+	 * When omitted, the sidebar/cache integration is disabled.
+	 */
+	chatTabId?: string;
 }
 
 export default function ChatConversationPage({
@@ -120,8 +139,10 @@ export default function ChatConversationPage({
 	unavailableMessage,
 	providerName,
 	createOnFirstMessage = false,
+	chatTabId,
 }: ChatConversationPageProps) {
 	const { connectionStatus, hostDir } = useShellular();
+	const [showSidebar, setShowSidebar] = useState(false);
 	const resolvedWorkspacePath = useMemo(
 		() => normalizeRemoteWorkspacePath(workspacePath, hostDir),
 		[hostDir, workspacePath],
@@ -133,9 +154,10 @@ export default function ChatConversationPage({
 	const [scrollAdjust, setScrollAdjust] = useState(0);
 	const [syncing, setSyncing] = useState(false);
 	const [activeSessionId, setActiveSessionId] = useState(sessionId);
-	const [displayTitle, setDisplayTitle] = useState(
-		() => getSessionActivity(agentId, sessionId)?.title ?? title,
-	);
+	const [displayTitle, setDisplayTitle] = useState(() => {
+		const activityTitle = getSessionActivity(agentId, sessionId)?.title;
+		return isRealTitle(activityTitle) ? activityTitle : title;
+	});
 	const [isStreaming, setIsStreaming] = useState(
 		getSessionStreaming(agentId, sessionId),
 	);
@@ -871,7 +893,15 @@ export default function ChatConversationPage({
 			}
 			setIsStreaming(getSessionStreaming(agentId, targetSessionId));
 			const activity = getSessionActivity(agentId, targetSessionId);
-			if (activity?.title) setDisplayTitle(activity.title);
+			// Ignore the "New Chat" placeholder the activity store seeds at session
+			// creation — it would otherwise stomp a real title (e.g. when an existing
+			// session is re-opened and its activity still carries the create-time
+			// placeholder). Fall back to the (real) `title` prop in that case.
+			if (isRealTitle(activity?.title)) {
+				setDisplayTitle(activity.title as string);
+			} else if (isRealTitle(title)) {
+				setDisplayTitle(title);
+			}
 			const pendingPermission = readPendingActivityPermission(
 				activity?.pendingPermission,
 			);
@@ -885,14 +915,54 @@ export default function ChatConversationPage({
 		};
 		refreshActivity();
 		return subscribeSessionActivities(refreshActivity);
-	}, [activeSessionId, agentId, handlePermissionRequest, sessionId]);
+	}, [activeSessionId, agentId, handlePermissionRequest, sessionId, title]);
 
+	// Reset the title only when the session identity changes (switching/creating
+	// a session), preferring any known activity title. This must NOT depend on
+	// the `title` prop: a host that feeds a live title back as `title` would
+	// otherwise re-run this and clobber the real activity title with the
+	// "New Chat" fallback. Live title updates are owned by the activity effect.
+	const lastTitleSessionRef = useRef<string | null>(null);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: title is the fallback only, intentionally not a re-run trigger
 	useEffect(() => {
 		const targetSessionId = activeSessionId || sessionId;
-		setDisplayTitle(
-			getSessionActivity(agentId, targetSessionId)?.title ?? title,
-		);
-	}, [activeSessionId, agentId, sessionId, title]);
+		if (lastTitleSessionRef.current === targetSessionId) return;
+		lastTitleSessionRef.current = targetSessionId;
+		const activityTitle = getSessionActivity(agentId, targetSessionId)?.title;
+		setDisplayTitle(isRealTitle(activityTitle) ? activityTitle : title);
+	}, [activeSessionId, agentId, sessionId]);
+
+	// Register this chat in the per-folder cache so the in-chat sidebar can list
+	// every chat opened in the folder without hitting the CLI. Records on mount
+	// (as a draft for new chats) and keeps sessionId/title fresh as they resolve.
+	useEffect(() => {
+		if (!chatTabId) return;
+		recordChatTab(workspacePath, {
+			id: chatTabId,
+			agentId,
+			sessionId: activeSessionId || sessionId,
+			title: displayTitle,
+		});
+	}, [
+		chatTabId,
+		workspacePath,
+		agentId,
+		activeSessionId,
+		sessionId,
+		displayTitle,
+	]);
+
+	// Let the device/back gesture close the sidebar before popping the page.
+	useEffect(() => {
+		if (!showSidebar) return;
+		actionStack.push({
+			id: "chat-sidebar",
+			action: () => setShowSidebar(false),
+		});
+		return () => {
+			actionStack.remove("chat-sidebar");
+		};
+	}, [showSidebar]);
 
 	useEffect(() => {
 		upsertAcpMessageRef.current = (incomingMessage: AcpMessage) => {
@@ -1008,7 +1078,21 @@ export default function ChatConversationPage({
 					aria-hidden="true"
 				/>
 			}
-			rightSlot={syncing ? <Loader size={18} mascot={false} /> : undefined}
+			rightSlot={
+				<>
+					{syncing && <Loader size={18} mascot={false} />}
+					{chatTabId && (
+						<button
+							type="button"
+							className="chat-sidebar-toggle haptic-trigger"
+							onClick={() => setShowSidebar(true)}
+							aria-label="Open chats"
+						>
+							<span className="icon-menu" aria-hidden="true" />
+						</button>
+					)}
+				</>
+			}
 		>
 			{loading && allMessages.length === 0 && (
 				<EmptyState message="Loading messages…" mascot="loading" />
@@ -1178,6 +1262,14 @@ export default function ChatConversationPage({
 					<ContextWindowDetails usage={contextWindowUsage} />
 				)}
 			</BottomSheet>
+			{chatTabId && (
+				<ChatSidebar
+					open={showSidebar}
+					onClose={() => setShowSidebar(false)}
+					workspacePath={workspacePath}
+					activeTabId={chatTabId}
+				/>
+			)}
 		</Page>
 	);
 

--- a/src/pages/chat/style.scss
+++ b/src/pages/chat/style.scss
@@ -27,6 +27,7 @@
     flex-shrink: 0;
   }
 
+
   .page-header-title-text {
     grid-column: 2;
     grid-row: 1;
@@ -251,4 +252,282 @@
   100% {
     background-position: -120% 0;
   }
+}
+
+// ─── Chat sidebar (slides in from the right) ───────────────────
+.chat-sidebar-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  color: var(--primary-text);
+  background: transparent;
+  border: none;
+
+  span[class^="icon-"] {
+    font-size: 20px;
+  }
+}
+
+.project-chat-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+
+  .project-chat-drawer-backdrop {
+    position: absolute;
+    inset: 0;
+    border: none;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.46);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    opacity: 0;
+    transition: opacity 200ms ease;
+  }
+
+  .project-chat-drawer-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(86vw, 360px);
+    display: flex;
+    flex-direction: column;
+    background: var(--popup-background, var(--primary));
+    border-left: 1px solid var(--popup-border-color, var(--card-border));
+    box-shadow: -18px 0 50px var(--shadow-color, rgba(0, 0, 0, 0.4));
+    padding-top: var(--sat, 0px);
+    padding-right: var(--sar, 0px);
+    padding-bottom: var(--sab, 0px);
+    transform: translateX(100%);
+    transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
+    will-change: transform;
+  }
+
+  &.is-open {
+    .project-chat-drawer-backdrop {
+      opacity: 1;
+    }
+    .project-chat-drawer-panel {
+      transform: translateX(0);
+    }
+  }
+
+  &.is-closing {
+    .project-chat-drawer-backdrop {
+      opacity: 0;
+    }
+    .project-chat-drawer-panel {
+      transform: translateX(100%);
+    }
+  }
+}
+
+.project-chat-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 12px 12px 16px;
+  border-bottom: 1px solid var(--card-border);
+
+  .project-chat-drawer-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--primary-text);
+
+    span:last-child {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    span[class^="icon-"] {
+      color: var(--secondary-text);
+      font-size: 16px;
+    }
+  }
+
+  .project-chat-drawer-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    border: none;
+    background: transparent;
+    color: var(--secondary-text);
+
+    span[class^="icon-"] {
+      font-size: 18px;
+    }
+  }
+}
+
+.project-chat-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.project-chat-drawer-empty {
+  margin: 12px 8px;
+  font-size: 13px;
+  color: var(--secondary-text);
+  text-align: center;
+}
+
+.project-chat-drawer-footer {
+  border-top: 1px solid var(--card-border);
+  padding: 12px 12px calc(12px + var(--sab, 0px));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.project-chat-new-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--secondary-text);
+}
+
+.project-chat-new-agents {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.project-chat-new-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--card-border);
+  background: var(--card-background, transparent);
+  color: var(--primary-text);
+  font-size: 14px;
+  font-weight: 600;
+  width: 100%;
+
+  span[class^="icon-"] {
+    font-size: 16px;
+  }
+
+  &--agent {
+    width: auto;
+    flex: 1 1 auto;
+    font-size: 13px;
+    padding: 9px 12px;
+  }
+}
+
+.project-chat-new-agent-icon {
+  width: 18px;
+  height: 18px;
+  font-size: 18px;
+}
+
+.project-chat-session-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-radius: 10px;
+
+  &[data-active="true"] {
+    background: var(--surface-strong, var(--card-background));
+  }
+}
+
+.project-chat-session-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  padding: 9px 8px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 10px;
+}
+
+.project-chat-session-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  color: var(--secondary-text);
+
+  span[class^="icon-"] {
+    font-size: 18px;
+  }
+
+  img {
+    width: 20px;
+    height: 20px;
+    border-radius: 5px;
+  }
+}
+
+.project-chat-session-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.project-chat-session-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--primary-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-chat-session-meta {
+  font-size: 11px;
+  color: var(--secondary-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-chat-session-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  margin-right: 4px;
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  color: var(--secondary-text);
+
+  span[class^="icon-"] {
+    font-size: 15px;
+  }
+}
+
+.project-chat-session-main .badge {
+  flex-shrink: 0;
 }

--- a/src/pages/sessions/index.tsx
+++ b/src/pages/sessions/index.tsx
@@ -7,6 +7,7 @@ import EmptyState from "components/EmptyState";
 import Loader from "components/Loader";
 import Page from "components/Page";
 import { getAgentIcon } from "lib/agents";
+import { chatTabId } from "lib/chatTabId";
 import toast from "lib/toast";
 import { formatRelativeTime } from "lib/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -194,77 +195,61 @@ export default function ChatSessionsPage({
 		}
 	}, [agent, backend, loadingMore, nextCursor, workspace]);
 
-	const openNewChatForWorkspace = useCallback(
-		async (path: string) => {
+	const openChat = useCallback(
+		async (opts: {
+			sessionId: string;
+			title: string;
+			workspacePath: string;
+		}) => {
+			const tabId = chatTabId(backend, opts.sessionId);
 			const ChatConversationPage = await import("pages/chat");
 			pushPage(
-				`new-${backend}-${path}-${Date.now()}`,
+				tabId,
 				<ChatConversationPage.default
-					sessionId=""
-					title="New Chat"
+					chatTabId={tabId}
+					sessionId={opts.sessionId}
+					title={opts.title}
 					agentId={backend}
-					workspacePath={path}
+					workspacePath={opts.workspacePath}
 					assistantName={agent.name}
 					agentAvailable={agentAvailable}
 					unavailableMessage={`${agent.name} is not available on this device.`}
 					providerName={agent.title}
 					agentCapabilities={agent?.capabilities}
-					createOnFirstMessage
-				/>,
-			);
-		},
-		[agent?.capabilities, agentAvailable, agent.title, agent.name, backend],
-	);
-
-	const openSession = useCallback(
-		async (session: AiSession) => {
-			if (!session.id) return;
-
-			const ChatConversationPage = await import("pages/chat");
-			pushPage(
-				session.id,
-				<ChatConversationPage.default
-					sessionId={session.id}
-					title={session?.title ?? session.id}
-					agentId={backend}
-					workspacePath={session.workspacePath ?? workspace ?? ""}
-					assistantName={agent.name}
-					agentAvailable={agentAvailable}
-					unavailableMessage={`${agent.name} is not available on this device.`}
-					providerName={agent.title}
-					agentCapabilities={agent?.capabilities}
-				/>,
-			);
-		},
-		[
-			agent?.capabilities,
-			agentAvailable,
-			agent.name,
-			agent.title,
-			backend,
-			workspace,
-		],
-	);
-
-	const openBookmarkedSession = useCallback(
-		async (bookmark: (typeof bookmarked)[number]) => {
-			const ChatConversationPage = await import("pages/chat");
-			pushPage(
-				bookmark.sessionId,
-				<ChatConversationPage.default
-					sessionId={bookmark.sessionId}
-					title={bookmark.title}
-					agentId={backend}
-					workspacePath={bookmark.workspacePath}
-					assistantName={agent.name}
-					agentAvailable={agentAvailable}
-					unavailableMessage={`${agent.name} is not available on this device.`}
-					providerName={agent.title}
-					agentCapabilities={agent?.capabilities}
+					createOnFirstMessage={!opts.sessionId}
 				/>,
 			);
 		},
 		[agent?.capabilities, agentAvailable, agent.name, agent.title, backend],
+	);
+
+	const openNewChatForWorkspace = useCallback(
+		(path: string) =>
+			openChat({ sessionId: "", title: "New Chat", workspacePath: path }),
+		[openChat],
+	);
+
+	const openSession = useCallback(
+		(session: AiSession) => {
+			if (!session.id) return;
+			openChat({
+				sessionId: session.id,
+				title: session.title ?? session.id,
+				workspacePath: session.workspacePath ?? workspace ?? "",
+			});
+		},
+		[openChat, workspace],
+	);
+
+	const openBookmarkedSession = useCallback(
+		(bookmark: (typeof bookmarked)[number]) => {
+			openChat({
+				sessionId: bookmark.sessionId,
+				title: bookmark.title,
+				workspacePath: bookmark.workspacePath,
+			});
+		},
+		[openChat],
 	);
 
 	useEffect(() => {
@@ -515,26 +500,26 @@ export default function ChatSessionsPage({
 																	{getBookmarkedMeta(bookmark)}
 																</span>
 															</div>
-															<button
-																type="button"
-																className="agent-sessions-pinned-unbookmark haptic-trigger"
-																onClick={(e) => {
-																	e.stopPropagation();
-																	togglePin({
-																		agentId: backend,
-																		sessionId: bookmark.sessionId,
-																		title: bookmark.title,
-																		workspacePath: bookmark.workspacePath,
-																		updatedAt: bookmark.updatedAt,
-																	});
-																}}
-																aria-label="Remove bookmark"
-															>
-																<span
-																	className="icon-bookmark-filled"
-																	aria-hidden="true"
-																/>
-															</button>
+														</button>
+														<button
+															type="button"
+															className="agent-sessions-pinned-unbookmark haptic-trigger"
+															onClick={(e) => {
+																e.stopPropagation();
+																togglePin({
+																	agentId: backend,
+																	sessionId: bookmark.sessionId,
+																	title: bookmark.title,
+																	workspacePath: bookmark.workspacePath,
+																	updatedAt: bookmark.updatedAt,
+																});
+															}}
+															aria-label="Remove bookmark"
+														>
+															<span
+																className="icon-bookmark-filled"
+																aria-hidden="true"
+															/>
 														</button>
 													</article>
 												))}

--- a/src/pages/sessions/style.scss
+++ b/src/pages/sessions/style.scss
@@ -252,7 +252,7 @@
     flex-direction: row;
     align-items: center;
     gap: 10px;
-    padding: 10px 10px 10px 12px;
+    padding: 10px 44px 10px 12px;
     border: none;
     background: transparent;
     color: var(--primary-text);
@@ -266,6 +266,9 @@
   }
 
   .agent-sessions-pinned-unbookmark {
+    position: absolute;
+    top: 8px;
+    right: 8px;
     flex-shrink: 0;
     width: 30px;
     height: 30px;

--- a/src/state/chatTabs.ts
+++ b/src/state/chatTabs.ts
@@ -1,0 +1,178 @@
+import type { AiBackend } from "@shellular/protocol";
+import file from "bridge/file";
+import appConfig from "lib/appConfig";
+import { useCallback, useSyncExternalStore } from "react";
+import { getHostInfo } from "./connection";
+
+// ─── Types ────────────────────────────────────────────────────
+
+/**
+ * A chat kept open in a project's consolidated workspace. One project can hold
+ * tabs from multiple agents (Claude, Codex, …), so each tab carries its own
+ * `agentId`. `sessionId` is "" for a freshly-opened tab that hasn't created its
+ * ACP session yet (no first message sent); it's filled in via {@link updateChatTab}
+ * once the conversation page reports the real id back.
+ */
+export interface ChatTab {
+	/** Stable local id for the tab, independent of the ACP session id. */
+	id: string;
+	agentId: AiBackend;
+	/** ACP session id, or "" until the first message creates the session. */
+	sessionId: string;
+	title: string;
+	createdAt: number;
+	updatedAt: number;
+}
+
+// ─── In-memory store ──────────────────────────────────────────
+// Keyed by project path; each value is the ordered list of open tabs for that
+// project. We keep a per-project cached snapshot array (stable reference between
+// emits) so useSyncExternalStore doesn't loop.
+
+const tabsByProject = new Map<string, ChatTab[]>();
+const listeners = new Set<() => void>();
+let loadedForHost = "";
+
+const EMPTY: ChatTab[] = [];
+
+function emit() {
+	for (const listener of Array.from(listeners)) listener();
+}
+
+export function subscribeChatTabs(listener: () => void) {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+/** Open tabs for a project, in display order (stable reference between emits). */
+export function getChatTabs(projectPath: string): ChatTab[] {
+	return tabsByProject.get(projectPath) ?? EMPTY;
+}
+
+// ─── Persistence ──────────────────────────────────────────────
+// Local to the device, keyed by host id — same convention as projects and
+// bookmarked sessions. The on-disk shape is { [projectPath]: ChatTab[] }.
+
+function chatTabsPath(hostId: string): string {
+	return `${appConfig.DATA_DIR}/chat-tabs-${hostId}.json`;
+}
+
+/** Load chat tabs for a host into the in-memory store. Idempotent per host. */
+export async function loadChatTabs(hostId: string): Promise<void> {
+	if (loadedForHost === hostId) return;
+	tabsByProject.clear();
+	try {
+		const path = chatTabsPath(hostId);
+		if (await file.exists(path)) {
+			const text = (await file.read(path, "text")) as string;
+			const parsed = JSON.parse(text) as Record<string, ChatTab[]>;
+			for (const [projectPath, tabs] of Object.entries(parsed)) {
+				if (Array.isArray(tabs) && tabs.length) {
+					tabsByProject.set(projectPath, tabs);
+				}
+			}
+		}
+	} catch {
+		// Corrupt/missing file — start empty.
+	}
+	loadedForHost = hostId;
+	emit();
+}
+
+/** Clear the store on disconnect so it reloads for the next host. */
+export function resetChatTabs() {
+	tabsByProject.clear();
+	loadedForHost = "";
+	emit();
+}
+
+async function persist(hostId: string): Promise<void> {
+	const out: Record<string, ChatTab[]> = {};
+	for (const [projectPath, tabs] of tabsByProject) {
+		if (tabs.length) out[projectPath] = tabs;
+	}
+	await file.write(chatTabsPath(hostId), JSON.stringify(out));
+}
+
+function activeHostId(): string | undefined {
+	return getHostInfo()?.id;
+}
+
+function setTabs(projectPath: string, tabs: ChatTab[]) {
+	if (tabs.length) tabsByProject.set(projectPath, tabs);
+	else tabsByProject.delete(projectPath);
+	emit();
+	const hostId = activeHostId();
+	if (hostId) persist(hostId).catch(console.error);
+}
+
+/**
+ * Record (upsert) a chat in a project's cache, keyed by its stable local `id`.
+ * Each chat calls this on mount and whenever its sessionId/title changes, so the
+ * sidebar can list every chat opened in the folder without hitting the CLI.
+ * Existing fields are only overwritten by meaningful values (never blanked, and
+ * never downgraded back to the "New Chat" placeholder).
+ */
+export function recordChatTab(
+	projectPath: string,
+	input: {
+		id: string;
+		agentId: AiBackend;
+		sessionId?: string;
+		title?: string;
+	},
+): void {
+	const tabs = getChatTabs(projectPath);
+	const index = tabs.findIndex((tab) => tab.id === input.id);
+	const now = Date.now();
+
+	if (index < 0) {
+		const tab: ChatTab = {
+			id: input.id,
+			agentId: input.agentId,
+			sessionId: input.sessionId ?? "",
+			title: input.title ?? "New Chat",
+			createdAt: now,
+			updatedAt: now,
+		};
+		setTabs(projectPath, [...tabs, tab]);
+		return;
+	}
+
+	const current = tabs[index];
+	const nextSessionId = input.sessionId || current.sessionId;
+	const nextTitle =
+		input.title && input.title !== "New Chat" ? input.title : current.title;
+	if (nextSessionId === current.sessionId && nextTitle === current.title) {
+		return;
+	}
+	const updated = [...tabs];
+	updated[index] = {
+		...current,
+		sessionId: nextSessionId,
+		title: nextTitle,
+		updatedAt: now,
+	};
+	setTabs(projectPath, updated);
+}
+
+/** Close a tab (does not touch the underlying ACP session). */
+export function removeChatTab(projectPath: string, tabId: string): void {
+	const tabs = getChatTabs(projectPath);
+	const updated = tabs.filter((tab) => tab.id !== tabId);
+	if (updated.length === tabs.length) return;
+	setTabs(projectPath, updated);
+}
+
+// ─── React binding ────────────────────────────────────────────
+
+/** Subscribe to the open chat tabs for a single project. */
+export function useChatTabs(projectPath: string): ChatTab[] {
+	const getSnapshot = useCallback(
+		() => getChatTabs(projectPath),
+		[projectPath],
+	);
+	return useSyncExternalStore(subscribeChatTabs, getSnapshot);
+}

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -28,6 +28,7 @@ import {
 	loadBookmarkedSessions,
 	resetBookmarkedSessions,
 } from "./bookmarkSessions";
+import { loadChatTabs, resetChatTabs } from "./chatTabs";
 import {
 	type BatteryInfo,
 	connectToServer,
@@ -313,6 +314,7 @@ export function ShellularProvider({ children }: { children: ReactNode }) {
 					.catch(console.error)
 					.finally(() => setLoadingProjects(false));
 				loadBookmarkedSessions(hostInfo.id).catch(console.error);
+				loadChatTabs(hostInfo.id).catch(console.error);
 			}
 
 			if (pendingSavedHostRef.current) {
@@ -340,6 +342,7 @@ export function ShellularProvider({ children }: { children: ReactNode }) {
 			setProjects([]);
 			setAgents({});
 			resetBookmarkedSessions();
+			resetChatTabs();
 			loadedProjectsForRef.current = "";
 		});
 

--- a/src/tabs/home/index.tsx
+++ b/src/tabs/home/index.tsx
@@ -6,6 +6,7 @@ import OfflineBanner from "components/OfflineBanner";
 import Scanner from "components/Scanner";
 import { AnimatePresence, motion } from "framer-motion";
 import { getAgentIcon } from "lib/agents";
+import { chatTabId } from "lib/chatTabId";
 import { getOnlineStatus } from "lib/utils";
 import { useEffect, useState } from "react";
 import { useShellular } from "state";
@@ -184,17 +185,20 @@ async function openSession(
 	session: SessionActivity,
 	agent?: ReturnType<typeof useShellular>["agents"][string],
 ) {
+	const agentName = agent?.name ?? session.agentId;
+	const tabId = chatTabId(session.agentId, session.sessionId);
 	const ChatConversationPage = await import("pages/chat");
 	pushPage(
-		`${session.agentId}-${session.sessionId}`,
+		tabId,
 		<ChatConversationPage.default
+			chatTabId={tabId}
 			sessionId={session.sessionId}
 			title={session.title || session.sessionId}
 			agentId={session.agentId}
 			workspacePath={session.workspacePath ?? ""}
-			assistantName={agent?.name ?? session.agentId}
+			assistantName={agentName}
 			agentAvailable={agent?.available ?? true}
-			unavailableMessage={`${agent?.name ?? session.agentId} is not available on this device.`}
+			unavailableMessage={`${agentName} is not available on this device.`}
 			providerName={agent?.title ?? session.agentId}
 			agentCapabilities={agent?.capabilities}
 		/>,

--- a/src/tabs/projects/ProjectList.tsx
+++ b/src/tabs/projects/ProjectList.tsx
@@ -3,6 +3,7 @@ import dialog from "bridge/dialog";
 import AppMenu from "components/AppMenu";
 import Loader from "components/Loader";
 import { getAgentIcon } from "lib/agents";
+import { chatTabId } from "lib/chatTabId";
 import { useCallback, useState } from "react";
 import { type ProjectInfo, useShellular } from "state";
 import type { AcpAgentInfo } from "state/acp";
@@ -41,18 +42,28 @@ export default function ProjectList({ projects, adding }: Props) {
 		setRemovingProjectPath(null);
 	};
 
-	const openProjectAgentChats = useCallback(
+	const openNewChat = useCallback(
 		async (project: ProjectInfo, agent: AcpAgentInfo) => {
+			if (project.path === "/") {
+				dialog.message(
+					"Choose a folder inside the filesystem root. The root directory itself cannot be opened as a project.",
+					"Invalid Project",
+				);
+				return;
+			}
+			const tabId = chatTabId(agent.id, "");
 			const ChatConversationPage = await import("pages/chat");
 			pushPage(
-				`project-${agent.id}-${project.path}-${Date.now()}`,
+				tabId,
 				<ChatConversationPage.default
+					chatTabId={tabId}
 					sessionId=""
 					title="New Chat"
 					agentId={agent.id}
 					workspacePath={project.path}
 					assistantName={agent.name}
 					providerName={agent.title || agent.name}
+					agentCapabilities={agent?.capabilities}
 					createOnFirstMessage
 				/>,
 			);
@@ -79,7 +90,6 @@ export default function ProjectList({ projects, adding }: Props) {
 								);
 								return;
 							}
-
 							const FileBrowserPage = await import("pages/files");
 							pushPage(
 								"project-explorer",
@@ -130,9 +140,15 @@ export default function ProjectList({ projects, adding }: Props) {
 						buttonClassName="project-item-menu-btn"
 						ariaLabel={`Menu for ${project.name}`}
 						items={[
+							...availableAgents.map((agent) => ({
+								icon: getAgentIcon(agent.id),
+								label: `New ${agent.title || agent.name} chat`,
+								onClick: () => openNewChat(project, agent),
+							})),
 							{
 								icon: "icon-terminal",
 								label: "Open in Terminal",
+								divider: true,
 								onClick: () => {
 									createTerminal({
 										cwd: project.path,
@@ -140,11 +156,6 @@ export default function ProjectList({ projects, adding }: Props) {
 									toToTab("terminals");
 								},
 							},
-							...availableAgents.map((agent) => ({
-								icon: getAgentIcon(agent.id),
-								label: `Open in ${agent.title || agent.name}`,
-								onClick: () => openProjectAgentChats(project, agent),
-							})),
 							{
 								icon: "icon-trash",
 								label: "Remove",


### PR DESCRIPTION
  Add a right slide-in sidebar inside the chat page listing every chat
  opened in the same folder, with a New button per available agent.
  Chats are cached locally per host (state/chatTabs) — sessionId + title
  —
  so the list never calls the CLI, and each chat self-registers via its
  stable chatTabId (also its page-stack id).

  - New: lib/chatTabId, state/chatTabs, pages/chat/ChatSidebar
  - ChatConversationPage gains a chatTabId prop + hamburger toggle
  - Route sessions/home/bookmarks/projects through plain ChatConversationPage pushes with collision-free ids
  - Treat "New Chat" as a placeholder title so a real title isn't clobbered back to "New Chat" after sync
  - Fix nested <button> in bookmarked session card